### PR TITLE
Remove bottom white bar in nav bar

### DIFF
--- a/src/app/_components/nav/NavBar.tsx
+++ b/src/app/_components/nav/NavBar.tsx
@@ -38,7 +38,7 @@ const NavBar: React.FC = () => {
     <>
       <header
         className={`fixed top-0 z-50 w-full transition-all duration-300 ${
-          isScrolled ? 'bg-white shadow-md text-black' : 'bg-transparent text-white border-b border-white/20'
+          isScrolled ? 'bg-white text-black' : 'bg-transparent text-white'
         }`}
       >
         <div className="container mx-auto px-4">


### PR DESCRIPTION
### Summary
tiny stylistic change, personally think nav bar looks better without the white border/line at bottom. 
### Before:
<img width="2600" height="1644" alt="Screenshot 2025-07-16 235329" src="https://github.com/user-attachments/assets/75834680-d51d-4d04-83ca-d422ac8ba3e9" />

### After:
<img width="2616" height="1535" alt="Screenshot 2025-07-16 235507" src="https://github.com/user-attachments/assets/c255ad8c-23bb-4de6-a1f5-9e44e9c33526" />
